### PR TITLE
Fix wrong unit V to °C for avg cell temp

### DIFF
--- a/custom_components/byd_battery_box/const.py
+++ b/custom_components/byd_battery_box/const.py
@@ -81,7 +81,7 @@ BMS_SENSOR_TYPES = {
     "warnings": ["Warnings", "warnings",None, None, None, None, EntityCategory.DIAGNOSTIC],
     "errors": ["Errors", "errors",None, None, None, None, EntityCategory.DIAGNOSTIC],
     "avg_c_v": ["Cells Average Voltage", "avg_c_v", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:lightning-bolt", None],
-    "avg_c_t": ["Cells Average Temperature", "avg_c_t", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, "V", "mdi:lightning-bolt", None],
+    "avg_c_t": ["Cells Average Temperature", "avg_c_t", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, "°C", "mdi:thermometer", None],
     "updated": ["Updated", "updated",SensorDeviceClass.TIMESTAMP, None, None, None, EntityCategory.DIAGNOSTIC],
 }
 


### PR DESCRIPTION
Change unit_of_measurement from V to °C and adjust icon. (Average Cell Temperature uses wrong unit and icon)