### PR TITLE
Fix for Homeassistant with pymodbus 3.11.1

### DIFF
--- a/custom_components/byd_battery_box/extmodbusclient.py
+++ b/custom_components/byd_battery_box/extmodbusclient.py
@@ -84,7 +84,7 @@ class ExtModbusClient:
 
         for attempt in range(retries+1):
             try:
-                data = await self._client.read_holding_registers(address=address, count=count, slave=unit_id)
+                data = await self._client.read_holding_registers(address=address, count=count, device_id=unit_id)
             except ModbusIOException as e:
                 _LOGGER.error(f'error reading registers. IO error. connected: {self._client.connected} address: {address} count: {count} unit id: {self._unit_id}')
                 return None
@@ -106,7 +106,7 @@ class ExtModbusClient:
                     _LOGGER.debug(f"Unknown data response error reading register retries: {attempt}/{retries} connected {self._client.connected} address: {address} count: {count} unit id: {self._unit_id}  {data}")
                 await asyncio.sleep(.2) 
 
-        if data.isError():
+        if data is None or data.isError():
             _LOGGER.error(f"error reading registers. retries: {attempt}/{retries} connected {self._client.connected} register: {address} count: {count} unit id: {self._unit_id} retries {retries} error: {data} ")
             return None
 
@@ -130,7 +130,7 @@ class ExtModbusClient:
         await self._check_and_reconnect()
 
         try:
-            result = await self._client.write_registers(address=address, values=payload, slave=unit_id)
+            result = await self._client.write_registers(address=address, values=payload, device_id=unit_id)
         except ModbusIOException as e:
             raise Exception(f'write_registers: IO error {self._client.connected} {e.fcode} {e}')
         except ConnectionException as e:

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -11,6 +11,7 @@ from homeassistant.core import callback
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.core import HomeAssistant
 from importlib.metadata import version
+from packaging import version as pkg_version
 
 from .const import (
     DOMAIN,
@@ -122,13 +123,23 @@ class Hub:
         self.update_entities()
 
     def check_pymodbus_version(self):
-        if version('pymodbus') is None:
-            _LOGGER.warning(f"pymodbus not found")
-        elif version('pymodbus') < self.PYMODBUS_VERSION:
-            raise Exception(f"pymodbus {version('pymodbus')} found, please update to {self.PYMODBUS_VERSION} or higher")
-        elif version('pymodbus') > self.PYMODBUS_VERSION:
-            _LOGGER.warning(f"newer pymodbus {version('pymodbus')} found")
-        #_LOGGER.debug(f"pymodbus {version('pymodbus')}")      
+        try:
+            current_version = version('pymodbus')
+            if current_version is None:
+                _LOGGER.warning(f"pymodbus not found")
+                return
+
+            current = pkg_version.parse(current_version)
+            required = pkg_version.parse(self.PYMODBUS_VERSION)
+
+            if current < required:
+                raise Exception(f"pymodbus {current_version} found, please update to {self.PYMODBUS_VERSION} or higher")
+            elif current > required:
+                _LOGGER.warning(f"newer pymodbus {current_version} found")
+            _LOGGER.debug(f"pymodbus {current_version}")
+        except Exception as e:
+            _LOGGER.error(f"Error checking pymodbus version: {e}")
+            raise  
 
     @toggle_busy
     async def async_update_data(self, _now: Optional[int] = None) -> dict:

--- a/custom_components/byd_battery_box/manifest.json
+++ b/custom_components/byd_battery_box/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/redpomodoro/byd_battery_box/",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/redpomodoro/byd_battery_box/issues",
-    "requirements": ["pymodbus>=3.8.3"],
-    "version": "0.1.16"
+    "requirements": ["pymodbus>=3.10.0"],
+    "version": "0.1.17"
   }


### PR DESCRIPTION
This fixes the integration is not starting in HA 2025.09.0 due to pymodbus version missmatch.