### PR TITLE
Add HACS Button in Readme for more user-friendly installation for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 
 <small>*HACS is a third party community store and is not included in Home Assistant out of the box.*</small>
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=TimWeyand&repository=byd_battery_box&category=integration)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=redpomodoro&repository=byd_battery_box&category=integration)
 
 ## Manual install
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,20 @@ Home assistant Custom Component for reading data from BYD Battery Box system ser
 > Note using other applications connecting to battery simulatousnely might give unexpected results. 
 
 # Installation
-Copy contents of custom_components folder to your home-assistant config/custom_components folder or install through HACS.
-After reboot of Home-Assistant, this integration can be configured through the integration setup UI.
+
+## HACS (recommended) 
+
+This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community Store).
+
+<small>*HACS is a third party community store and is not included in Home Assistant out of the box.*</small>
+
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=TimWeyand&repository=byd_battery_box)
+
+## Manual install
+
+1. Download and copy Installation to your home-assistant config/custom_components folder.
+
+2. After reboot of Home-Assistant, this integration can be configured through the integration setup UI.
 
 # Data Updates
 The key BMU Status data will by default refreshed 30 seconds. 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This card is available in [HACS](https://hacs.xyz/) (Home Assistant Community St
 
 <small>*HACS is a third party community store and is not included in Home Assistant out of the box.*</small>
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=TimWeyand&repository=byd_battery_box)
+[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=TimWeyand&repository=byd_battery_box&category=integration)
 
 ## Manual install
 

--- a/custom_components/byd_battery_box/manifest.json
+++ b/custom_components/byd_battery_box/manifest.json
@@ -1,12 +1,13 @@
 {
-    "domain": "byd_battery_box",
-    "name": "BYD Battery Box",
-    "codeowners": ["@redpomodoro"],
-    "config_flow": true,
-    "dependencies": [],
-    "documentation": "https://github.com/redpomodoro/byd_battery_box/",
-    "iot_class": "local_polling",
-    "issue_tracker": "https://github.com/redpomodoro/byd_battery_box/issues",
-    "requirements": ["pymodbus==3.11.1"],
-    "version": "0.1.17"
-  }
+  "domain": "byd_battery_box",
+  "name": "BYD Battery Box",
+  "codeowners": ["@redpomodoro"],
+  "config_flow": true,
+  "dependencies": [],
+  "documentation": "https://github.com/redpomodoro/byd_battery_box/",
+  "iot_class": "local_polling",
+  "issue_tracker": "https://github.com/redpomodoro/byd_battery_box/issues",
+  "requirements": ["pymodbus==3.11.1"],
+  "version": "0.1.17",
+  "integration_type": "hub"
+}

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,6 @@
 {
-    "name": "BYD Battery Box",
-    "homeassistant": "2024.4.0"
-  }
+  "name": "BYD Battery Box",
+  "homeassistant": "2024.4.0",
+  "content_in_root": false,
+  "render_readme": true
+}


### PR DESCRIPTION
The Button [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=redpomodoro&repository=byd_battery_box&category=integration) was added for better usability for new users