### PR TITLE
Min/Max Cell Voltage

### DIFF
--- a/custom_components/byd_battery_box/button.py
+++ b/custom_components/byd_battery_box/button.py
@@ -99,16 +99,15 @@ class BydBoxButton(ButtonEntity):
         parts = self._key.split('_')
         device = parts[0]
         if 'bms' in device:
-            device_id = int(device[-1])
+            device_id = int(device.replace('bms','').split('_')[0])
         else:
             device_id = 0
 
-        if self._key.endswith('reset_history'):
-            # Reset history values (all BMS when device_id==0)
-            self._hub.reset_history(device_id)
+        if self._key.endswith('reset_history_cell_voltage'):
+            self._hub.reset_history_cell_voltage(device_id)
             return
 
-        # default: update_log_history
+        # default: update log history buttons
         try:
             log_depth = int(float(parts[-1]) * 0.05)
         except Exception:

--- a/custom_components/byd_battery_box/button.py
+++ b/custom_components/byd_battery_box/button.py
@@ -93,14 +93,26 @@ class BydBoxButton(ButtonEntity):
     async def async_press(self) -> None:
         """Async: Handle button press"""
 
+        # Key patterns:
+        # - update_log_history_XXX
+        # - reset_history
         parts = self._key.split('_')
-        log_depth = int(float(parts[-1]) * 0.05)
         device = parts[0]
         if 'bms' in device:
             device_id = int(device[-1])
         else:
             device_id = 0
 
+        if self._key.endswith('reset_history'):
+            # Reset history values (all BMS when device_id==0)
+            self._hub.reset_history(device_id)
+            return
+
+        # default: update_log_history
+        try:
+            log_depth = int(float(parts[-1]) * 0.05)
+        except Exception:
+            log_depth = 0
         self._hub.start_update_log_history(device_id, log_depth)
 
     @property

--- a/custom_components/byd_battery_box/bydboxclient.py
+++ b/custom_components/byd_battery_box/bydboxclient.py
@@ -545,6 +545,20 @@ class BydBoxClient(ExtModbusClient):
         self.data[f'bms{bms_id}_cell_balancing'] = cell_balancing
         self.data[f'bms{bms_id}_cell_voltages'] = cell_voltages
         self.data[f'bms{bms_id}_avg_c_v'] = avg_cell_voltage
+        # Update history of average cell voltage (max/min)
+        max_key = f'bms{bms_id}_max_history_avg_c_v'
+        min_key = f'bms{bms_id}_min_history_avg_c_v'
+        prev_max = self.data.get(max_key)
+        prev_min = self.data.get(min_key)
+        try:
+            if prev_max is None or avg_cell_voltage > prev_max:
+                self.data[max_key] = avg_cell_voltage
+            if prev_min is None or avg_cell_voltage < prev_min:
+                self.data[min_key] = avg_cell_voltage
+        except Exception:
+            # In case previous values are not numeric, reset to current
+            self.data[max_key] = avg_cell_voltage
+            self.data[min_key] = avg_cell_voltage
 
         self.data[f'bms{bms_id}_cell_temps'] = cell_temps
         self.data[f'bms{bms_id}_avg_c_t'] = avg_cell_temp

--- a/custom_components/byd_battery_box/const.py
+++ b/custom_components/byd_battery_box/const.py
@@ -30,7 +30,7 @@ BMU_BUTTON_TYPES = {
     "update_log_history_500": ["Update last 500 log entries", "update_log_history_500", None, None, None, None, None],
     "update_log_history_1000": ["Update last 1000 log entries", "update_log_history_1000", None, None, None, None, None],
     "update_log_history_2000": ["Update last 2000 log entries", "update_log_history_2000", None, None, None, None, None],
-    "reset_history": ["Reset history values", "reset_history", None, None, None, "mdi:backup-restore", None],
+    "reset_history_cell_voltage": ["Reset history cell voltage", "reset_history_cell_voltage", None, None, None, "mdi:restore-alert", None],
 }
 
 BMU_SENSOR_TYPES = {
@@ -92,6 +92,8 @@ BMS_SENSOR_TYPES = {
     "max_history_avg_c_v": ["Max history average voltage", "max_history_avg_c_v", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:chart-line", None],
     "min_history_avg_c_v": ["Min history average voltage", "min_history_avg_c_v", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:chart-line", None],
     "avg_c_t": ["Cells average temperature", "avg_c_t", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, "°C", "mdi:lightning-bolt", None],
+    "max_history_cell_voltage": ["Max history cell voltage", "max_history_cell_voltage", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:lightning-bolt", None],
+    "min_history_cell_voltage": ["Min history cell voltage", "min_history_cell_voltage", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:lightning-bolt", None],
     "updated": ["Updated", "updated",SensorDeviceClass.TIMESTAMP, None, None, None, EntityCategory.DIAGNOSTIC],
     "last_log": ["Last log", "last_log",None, None, None, None, EntityCategory.DIAGNOSTIC],
     "b_total": ["Balancing total", "b_total",None, None, None, None, None],

--- a/custom_components/byd_battery_box/const.py
+++ b/custom_components/byd_battery_box/const.py
@@ -30,6 +30,7 @@ BMU_BUTTON_TYPES = {
     "update_log_history_500": ["Update last 500 log entries", "update_log_history_500", None, None, None, None, None],
     "update_log_history_1000": ["Update last 1000 log entries", "update_log_history_1000", None, None, None, None, None],
     "update_log_history_2000": ["Update last 2000 log entries", "update_log_history_2000", None, None, None, None, None],
+    "reset_history": ["Reset history values", "reset_history", None, None, None, "mdi:backup-restore", None],
 }
 
 BMU_SENSOR_TYPES = {
@@ -88,6 +89,8 @@ BMS_SENSOR_TYPES = {
     "warnings": ["Warnings", "warnings",None, None, None, None, EntityCategory.DIAGNOSTIC],
     "errors": ["Errors", "errors",None, None, None, None, EntityCategory.DIAGNOSTIC],
     "avg_c_v": ["Cells average voltage", "avg_c_v", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:lightning-bolt", None],
+    "max_history_avg_c_v": ["Max history average voltage", "max_history_avg_c_v", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:chart-line", None],
+    "min_history_avg_c_v": ["Min history average voltage", "min_history_avg_c_v", SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT, "V", "mdi:chart-line", None],
     "avg_c_t": ["Cells average temperature", "avg_c_t", SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT, "°C", "mdi:lightning-bolt", None],
     "updated": ["Updated", "updated",SensorDeviceClass.TIMESTAMP, None, None, None, EntityCategory.DIAGNOSTIC],
     "last_log": ["Last log", "last_log",None, None, None, None, EntityCategory.DIAGNOSTIC],

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -225,3 +225,27 @@ class Hub:
     def start_update_log_history(self, unit_id, log_depth):
          _LOGGER.info(f"Scheduled {DEVICE_TYPES[unit_id]} log update for up to {log_depth*20} log entries.")
          self._update_log_history_depth = [unit_id, log_depth]
+
+    def reset_history(self, unit_id: int | None = None):
+         """Reset history values for average cell voltage max/min.
+         unit_id: 0 for BMU (apply to all BMS), 1..n for specific BMS.
+         """
+         try:
+             towers = int(self.data.get('towers') or 0)
+         except Exception:
+             towers = 0
+         ids = []
+         if unit_id is None or unit_id == 0:
+             ids = list(range(1, towers + 1))
+         else:
+             ids = [unit_id]
+         for bms_id in ids:
+             max_key = f'bms{bms_id}_max_history_avg_c_v'
+             min_key = f'bms{bms_id}_min_history_avg_c_v'
+             # Remove keys to allow reinitialization at next update
+             if max_key in self.data:
+                 del self.data[max_key]
+             if min_key in self.data:
+                 del self.data[min_key]
+         _LOGGER.info(f"Reset history values for BMS ids: {ids}")
+         self.update_entities()

--- a/custom_components/byd_battery_box/hub.py
+++ b/custom_components/byd_battery_box/hub.py
@@ -226,26 +226,23 @@ class Hub:
          _LOGGER.info(f"Scheduled {DEVICE_TYPES[unit_id]} log update for up to {log_depth*20} log entries.")
          self._update_log_history_depth = [unit_id, log_depth]
 
-    def reset_history(self, unit_id: int | None = None):
-         """Reset history values for average cell voltage max/min.
-         unit_id: 0 for BMU (apply to all BMS), 1..n for specific BMS.
-         """
-         try:
-             towers = int(self.data.get('towers') or 0)
-         except Exception:
-             towers = 0
-         ids = []
-         if unit_id is None or unit_id == 0:
-             ids = list(range(1, towers + 1))
+    def reset_history_cell_voltage(self, unit_id:int):
+         """Reset stored per-cell min/max history for one BMS or all (unit_id=0)."""
+         if unit_id == 0:
+             ids = range(1, self._bydclient._bms_qty + 1)
          else:
              ids = [unit_id]
          for bms_id in ids:
-             max_key = f'bms{bms_id}_max_history_avg_c_v'
-             min_key = f'bms{bms_id}_min_history_avg_c_v'
-             # Remove keys to allow reinitialization at next update
-             if max_key in self.data:
-                 del self.data[max_key]
-             if min_key in self.data:
-                 del self.data[min_key]
-         _LOGGER.info(f"Reset history values for BMS ids: {ids}")
+             for suffix in [
+                 '_max_history_cell_voltage',
+                 '_max_history_cell_voltage_cells',
+                 '_min_history_cell_voltage',
+                 '_min_history_cell_voltage_cells',
+             ]:
+                 key = f'bms{bms_id}{suffix}'
+                 if key in self._bydclient.data:
+                     try:
+                         del self._bydclient.data[key]
+                     except Exception:
+                         self._bydclient.data[key] = None
          self.update_entities()

--- a/custom_components/byd_battery_box/manifest.json
+++ b/custom_components/byd_battery_box/manifest.json
@@ -7,6 +7,6 @@
     "documentation": "https://github.com/redpomodoro/byd_battery_box/",
     "iot_class": "local_polling",
     "issue_tracker": "https://github.com/redpomodoro/byd_battery_box/issues",
-    "requirements": ["pymodbus==3.11.1"],
     "version": "0.1.17"
   }
+  "requirements": ["pymodbus>=3.10.0"],


### PR DESCRIPTION
* This change adds min/max cell voltage
* If the integration or home assistant reloads/restarts, it tries to load data from historical data

I use it to show the max/min cell voltage in a BYD Visualization card https://github.com/TimWeyand/byd_battery_box_visualization

I only get byd_battery_box with the Pull Request https://github.com/redpomodoro/byd_battery_box/pull/27 to start and only tested with this Version

<img width="371" height="848" alt="preview" src="https://github.com/user-attachments/assets/42ec9a8d-7c8c-4bce-b11b-0b00fed21b08" />

